### PR TITLE
Support .net Framework 4.6.1+ from AspNetCore

### DIFF
--- a/src/Swashbuckle.AspNetCore.Examples/Swashbuckle.AspNetCore.Examples.csproj
+++ b/src/Swashbuckle.AspNetCore.Examples/Swashbuckle.AspNetCore.Examples.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>net461;netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added .net 4.6.1 to allowed targetframeworks since aspenetcore can support either .net framework or .net standard