### PR TITLE
Fix array serialize and null value ignore

### DIFF
--- a/src/Swashbuckle.AspNetCore.Examples/ExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Examples/ExamplesOperationFilter.cs
@@ -39,6 +39,9 @@ namespace Swashbuckle.AspNetCore.Examples
                     var provider = (IExamplesProvider)Activator.CreateInstance(attr.ExamplesProviderType);
 
                     var parts = schema.Ref.Split('/');
+                    if (parts == null)
+                        continue;
+                    
                     var name = parts.Last();
 
                     var definitionToUpdate = schemaRegistry.Definitions[name];
@@ -74,7 +77,7 @@ namespace Swashbuckle.AspNetCore.Examples
                     if (response.Value != null)
                     {
                         var provider = (IExamplesProvider)Activator.CreateInstance(attr.ExamplesProviderType);
-                        var serializerSettings = new JsonSerializerSettings { ContractResolver = attr.ContractResolver };
+                        var serializerSettings = new JsonSerializerSettings { ContractResolver = attr.ContractResolver, NullValueHandling = NullValueHandling.Ignore };
                         response.Value.Examples = FormatAsJson(provider, serializerSettings);
                     }
                 }

--- a/src/Swashbuckle.AspNetCore.Examples/ExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Examples/ExamplesOperationFilter.cs
@@ -38,7 +38,7 @@ namespace Swashbuckle.AspNetCore.Examples
                 {
                     var provider = (IExamplesProvider)Activator.CreateInstance(attr.ExamplesProviderType);
 
-                    var parts = schema.Ref.Split('/');
+                    var parts = schema.Ref?.Split('/');
                     if (parts == null)
                         continue;
                     


### PR DESCRIPTION
When trying to serialize an array/list type property, an exception is thrown on schema.Ref as it's not a custom type.  

Additionally added NullValueHandling for the other method overload for consistency, as null values were being serialized