### PR TITLE
Fixed a null argument exception that occurs if the parameterDescription.Type is null

### DIFF
--- a/src/Swashbuckle.AspNetCore.Examples/DescriptionOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Examples/DescriptionOperationFilter.cs
@@ -49,7 +49,10 @@ namespace Swashbuckle.AspNetCore.Examples
         {
             foreach (var parameterDescription in apiDescription.ParameterDescriptions)
             {
-                UpdateDescriptions(schemaRegistry, parameterDescription.Type, true);
+                if (parameterDescription.Type != null)
+                {
+                    UpdateDescriptions(schemaRegistry, parameterDescription.Type, true);
+                }
             }
         }
 


### PR DESCRIPTION
It's possible for a route parameter to have a null type.

Simple, but Contrived Example
[HttpDelete"api/{officeId}/{userId}")]
public ActionResult DeleteUser(string userId)
{
...
}

In this case officeId is in the route but not used by the endpoint.  ApiExplorer gets the type from the endpoint parameters, so in this case when you call .Type, you get null for officeId.