### PR TITLE
Remove trailing semicolon from the auth summary

### DIFF
--- a/src/Swashbuckle.AspNetCore.Examples/AppendAuthorizeToSummaryOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Examples/AppendAuthorizeToSummaryOperationFilter.cs
@@ -25,7 +25,7 @@ namespace Swashbuckle.AspNetCore.Examples
                 AppendPolicies(authorizeAttributes, authorizationDescription);
                 AppendRoles(authorizeAttributes, authorizationDescription);
 
-                authorizationDescription.Append(")");
+                authorizationDescription.TrimEnd(';').Append(")");
 
                 operation.Summary += authorizationDescription;
             }


### PR DESCRIPTION
As I understand, the semicolon is used to separate policies list from the roles list. Anyhow, the semicolon also remains at the end as well, which does not look good. Can it be trimmed? 😊